### PR TITLE
Fix worker_machineset_suffix default to prevent validation failure

### DIFF
--- a/roles/scale_ocp_workers/defaults/main.yml
+++ b/roles/scale_ocp_workers/defaults/main.yml
@@ -16,7 +16,7 @@ worker_instance_type: ""
 # Custom suffix for new MachineSets when instance type differs
 # Example: "gpu", "highmem", "compute"
 # Results in names like: ocp-xjgsc-worker-us-east-2a-gpu
-worker_machineset_suffix: ""
+worker_machineset_suffix: "compute"
 
 # Timeout settings for waiting for nodes to become Ready
 worker_scale_timeout: 600


### PR DESCRIPTION
## Summary

- [scale_ocp_workers] Set `worker_machineset_suffix` default from `""` to `"compute"`
- Fixes validation failure when creating new MachineSets with a different instance type

## Details

When a user orders a cluster with a `worker_instance_type` that differs from the pool's existing instance type, the `scale_ocp_workers` role takes the "create new MachineSets" path. This path validates that `worker_machineset_suffix` is not empty — but the default was `""`, causing the task to always fail:

```
TASK [agnosticd.cloud_provider_aws.scale_ocp_workers : Validate worker_machineset_suffix is provided]
fatal: [localhost]: FAILED! => {"msg": "worker_machineset_suffix is required when creating MachineSets with a different instance type"}
```

Setting the default to `"compute"` provides a sensible generic suffix (e.g., `ocp-xjgsc-worker-us-east-2a-compute`) while still allowing callers to override it for specific use cases like `"gpu"` or `"highmem"`.

## Test plan

- [x] Deploy `ocp-cluster-aws` with `worker_instance_count_param: 2` and a `worker_instance_type` that differs from the pool's default
- [x] Verify the scale role creates new MachineSets with the `-compute` suffix
- [x] Verify worker nodes become Ready