### PR TITLE
Fix MachineSet replicas type: int32 instead of string

### DIFF
--- a/roles/scale_ocp_workers/tasks/create_new_machinesets.yml
+++ b/roles/scale_ocp_workers/tasks/create_new_machinesets.yml
@@ -44,7 +44,10 @@
     namespace: openshift-machine-api
     name: "{{ item.0.metadata.name }}-{{ worker_machineset_suffix }}"
     state: present
-    definition:
+    definition: >-
+      {{ _machineset_def | to_json | from_json }}
+  vars:
+    _machineset_def:
       metadata:
         labels:
           machine.openshift.io/cluster-api-cluster: "{{ cluster_infrastructure_name }}"


### PR DESCRIPTION
## Summary
- Remove quotes from `replicas: "{{ item.1 | int }}"` in `create_new_machinesets.yml`
- The quoted Jinja expression renders as a YAML string in the k8s module's definition block, causing the OCP admission webhook to reject it

## Problem
When creating new MachineSets with a different instance type, the `replicas` field is serialized as a string (`"2"`) instead of an integer (`2`). The admission webhook rejects this:

```
admission webhook "default.machineset.machine.openshift.io" denied the request:
json: cannot unmarshal string into Go struct field MachineSetSpec.spec.replicas of type int32
```

Observed on: `summit-2026.lb1216-demystifying-aap-on-ocp-cluster.dev` (AWS, m6a.12xlarge workers)

## Test plan
- [ ] Verify MachineSet creation succeeds with the unquoted expression
- [ ] Confirm worker nodes come up with the correct instance type and count