### PR TITLE
Add check that instances are running before continuing

### DIFF
--- a/roles/lifecycle/tasks/main.yml
+++ b/roles/lifecycle/tasks/main.yml
@@ -33,7 +33,7 @@
       wait: false
       instance_ids: "{{ _instance_ids_running }}"
 
-  - name: Start instances
+  - name: Start instances and wait for them to be running
     when:
     - ACTION == 'start'
     - _instance_ids_stopped | length > 0
@@ -45,10 +45,25 @@
         | map(attribute="instance_id")
         | list
         }}
-    amazon.aws.ec2_instance:
-      state: running
-      wait: false
-      instance_ids: "{{ _instance_ids_stopped }}"
+    block:
+    - name: Start instances
+      amazon.aws.ec2_instance:
+        state: running
+        wait: false
+        instance_ids: "{{ _instance_ids_stopped }}"
+
+    - name: Wait for instances to be running
+      amazon.aws.ec2_instance_info:
+        instance_ids: "{{ _instance_ids_stopped }}"
+      register: r_started_instances
+      until: >-
+        r_started_instances.instances
+        | map(attribute='state.name')
+        | select('ne', 'running')
+        | list
+        | length == 0
+      retries: 60
+      delay: 10
 
   - name: Report status
     when: ACTION == 'status'


### PR DESCRIPTION
Make sure that all instances are in fact running after starting before continuing.